### PR TITLE
Exception on WKContentRuleListStore.default()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Requires Xcode 11 and macOS 10.15 or better.
 Open the project in Xcode then build and run the DuckDuckGo scheme.
 
 ### SwiftLint
-We use [SwifLint](https://github.com/realm/SwiftLint) for enforcing Swift style and conventions, so you'll need to [install it](https://github.com/realm/SwiftLint#installation).
+We use [SwiftLint](https://github.com/realm/SwiftLint) for enforcing Swift style and conventions, so you'll need to [install it](https://github.com/realm/SwiftLint#installation).
 
 ### Fonts
 We use Proxima Nova fonts which are proprietary and cannot be committed to source control, see [fonts](https://github.com/duckduckgo/privacy-essentials-safari/tree/develop/fonts/licensed). 

--- a/TrackerBlockingFramework/BlockerListManager.swift
+++ b/TrackerBlockingFramework/BlockerListManager.swift
@@ -68,16 +68,19 @@ public class DefaultBlockerListManager: BlockerListManager {
             os_log("Failed to encode rules", log: generalLog, type: .error)
             return nil
         }
-        
-        if let store = WKContentRuleListStore.default() {
-            store.compileContentRuleList(forIdentifier: "XXX", encodedContentRuleList: String(data: data, encoding: .utf8)!) { _, error in
-                if let error = error {
-                    os_log("Failed to to compile rules %{public}s", log: generalLog, type: .error, error.localizedDescription)
+
+        DispatchQueue.main.async {
+            if let store = WKContentRuleListStore.default() {
+                store.compileContentRuleList(forIdentifier: "XXX", encodedContentRuleList: String(data: data, encoding: .utf8)!) { _, error in
+                    if let error = error {
+                        os_log("Failed to to compile rules %{public}s", log: generalLog, type: .error, error.localizedDescription)
+                    }
                 }
+            } else {
+                os_log("Failed to access the default WKContentRuleListStore for rules compiliation checking", log: generalLog, type: .error)
             }
-        } else {
-            os_log("Failed to access the default WKContentRuleListStore for rules compiliation checking", log: generalLog, type: .error)
         }
+
         return data
     }
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1144193759412024/1200421820541753/f

**Description**:
Calling default store of WKContentRuleListStore on the main thread

**Steps to test this PR**:
1. Make sure `WKContentRuleListStore.default()` is always executed on the main thread


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
