### PR TITLE
Name changed to "DuckDuckGo Privacy for Safari"

### DIFF
--- a/App/Base.lproj/Main.storyboard
+++ b/App/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -114,7 +114,7 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                     <connections>
                         <outlet property="debugMenu" destination="wpr-3q-Mcd" id="GSQ-Gk-xZj"/>
                     </connections>
@@ -150,7 +150,7 @@
         <scene sceneID="hIz-AP-VOD">
             <objects>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-                <viewController showSeguePresentationStyle="single" id="XfG-lQ-9wD" customClass="MainViewController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController showSeguePresentationStyle="single" id="XfG-lQ-9wD" customClass="MainViewController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
                         <rect key="frame" x="0.0" y="0.0" width="900" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -181,7 +181,7 @@
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Uzr-0X-7wL">
                                 <rect key="frame" x="0.0" y="320" width="210" height="180"/>
                                 <subviews>
-                                    <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="J6P-2m-qQh" userLabel="Section Button" customClass="SectionButton" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="J6P-2m-qQh" userLabel="Section Button" customClass="SectionButton" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="120" width="210" height="60"/>
                                         <view key="contentView" id="bX0-Hx-0fO">
                                             <rect key="frame" x="0.0" y="0.0" width="210" height="60"/>
@@ -194,7 +194,7 @@
                                                     <rect key="frame" x="0.0" y="-2" width="210" height="5"/>
                                                 </box>
                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hb0-ib-rpC">
-                                                    <rect key="frame" x="18" y="20" width="55" height="21"/>
+                                                    <rect key="frame" x="18" y="20" width="54" height="21"/>
                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Home" id="n9W-rC-dVl">
                                                         <font key="font" metaFont="systemSemibold" size="18"/>
                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -231,7 +231,7 @@
                                             <outlet property="label" destination="Hb0-ib-rpC" id="sM9-b4-Zn2"/>
                                         </connections>
                                     </box>
-                                    <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="ryO-Y9-5T6" userLabel="Section Button" customClass="SectionButton" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="ryO-Y9-5T6" userLabel="Section Button" customClass="SectionButton" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="60" width="210" height="60"/>
                                         <view key="contentView" id="UDQ-4l-MkG">
                                             <rect key="frame" x="0.0" y="0.0" width="210" height="60"/>
@@ -244,7 +244,7 @@
                                                     <rect key="frame" x="0.0" y="-2" width="210" height="5"/>
                                                 </box>
                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gyh-oR-IZE">
-                                                    <rect key="frame" x="18" y="20" width="158" height="21"/>
+                                                    <rect key="frame" x="18" y="20" width="157" height="21"/>
                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Unprotected Sites" id="PCA-Tc-qMw">
                                                         <font key="font" metaFont="systemSemibold" size="18"/>
                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -281,7 +281,7 @@
                                             <outlet property="label" destination="gyh-oR-IZE" id="rpC-MA-jRg"/>
                                         </connections>
                                     </box>
-                                    <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="sfB-pB-4F4" userLabel="Section Button" customClass="SectionButton" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="sfB-pB-4F4" userLabel="Section Button" customClass="SectionButton" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="210" height="60"/>
                                         <view key="contentView" id="ugv-il-D4k">
                                             <rect key="frame" x="0.0" y="0.0" width="210" height="60"/>
@@ -294,7 +294,7 @@
                                                     <rect key="frame" x="0.0" y="-2" width="210" height="5"/>
                                                 </box>
                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OGJ-5a-nbM">
-                                                    <rect key="frame" x="18" y="20" width="141" height="21"/>
+                                                    <rect key="frame" x="18" y="20" width="140" height="21"/>
                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Share Feedback" id="GmJ-LU-FKd">
                                                         <font key="font" metaFont="systemSemibold" size="18"/>
                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -376,7 +376,7 @@
         <!--Send Feedback View Controller-->
         <scene sceneID="6KS-NO-xBy">
             <objects>
-                <viewController storyboardIdentifier="SendFeedback" id="KsG-jK-kKk" customClass="SendFeedbackViewController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SendFeedback" id="KsG-jK-kKk" customClass="SendFeedbackViewController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="lta-Uq-f2F">
                         <rect key="frame" x="0.0" y="0.0" width="690" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -391,7 +391,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="690" height="500"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Gn9-QS-Awt">
-                                        <rect key="frame" x="49" y="439" width="173" height="26"/>
+                                        <rect key="frame" x="49" y="439" width="172" height="26"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Help Us Improve" id="hpb-0h-nC7">
                                             <font key="font" metaFont="systemBold" size="22"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -407,8 +407,8 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rlz-64-DEm">
-                                        <rect key="frame" x="51" y="415" width="567" height="16"/>
-                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Submitting anonymous feedback helps us improve DuckDuckGo Privacy Essentials for Safari." id="MQM-3V-ZA7">
+                                        <rect key="frame" x="51" y="415" width="502" height="16"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Submitting anonymous feedback helps us improve DuckDuckGo Privacy for Safari." id="MQM-3V-ZA7">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -448,7 +448,7 @@
                                         </scroller>
                                     </scrollView>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qsl-9j-tBO">
-                                        <rect key="frame" x="47" y="180" width="83" height="32"/>
+                                        <rect key="frame" x="46" y="181" width="77" height="32"/>
                                         <buttonCell key="cell" type="push" title="Submit" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bHN-sH-lDc">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -497,30 +497,30 @@
         <!--Trusted Sites View Controller-->
         <scene sceneID="ynG-g0-0fY">
             <objects>
-                <viewController storyboardIdentifier="TrustedSites" id="GZA-B9-v0r" customClass="TrustedSitesViewController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TrustedSites" id="GZA-B9-v0r" customClass="TrustedSitesViewController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="TQc-Lz-EYw">
-                        <rect key="frame" x="0.0" y="0.0" width="692" height="500"/>
+                        <rect key="frame" x="0.0" y="0.0" width="712" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <containerView translatesAutoresizingMaskIntoConstraints="NO" id="HCw-sJ-1SX">
-                                <rect key="frame" x="0.0" y="0.0" width="692" height="500"/>
+                                <rect key="frame" x="0.0" y="0.0" width="712" height="500"/>
                                 <connections>
                                     <segue destination="t6J-9g-unl" kind="embed" id="WR4-Fj-Y26"/>
                                 </connections>
                             </containerView>
                             <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="100" horizontalPageScroll="10" verticalLineScroll="100" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzd-oU-6hJ">
-                                <rect key="frame" x="51" y="0.0" width="591" height="500"/>
+                                <rect key="frame" x="51" y="0.0" width="611" height="500"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="xgs-bV-kmC">
-                                    <rect key="frame" x="0.0" y="0.0" width="591" height="500"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="611" height="500"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="100" viewBased="YES" id="mLd-CF-Xnz">
-                                            <rect key="frame" x="0.0" y="0.0" width="591" height="500"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="611" height="500"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="586" minWidth="40" maxWidth="1000" id="Jc3-sP-dr8">
+                                                <tableColumn width="554" minWidth="40" maxWidth="1000" id="Jc3-sP-dr8">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -533,11 +533,11 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="Header" id="9Z7-mT-FYE">
-                                                            <rect key="frame" x="0.0" y="0.0" width="586" height="100"/>
+                                                            <rect key="frame" x="10" y="0.0" width="566" height="100"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aBi-uE-RQS">
-                                                                    <rect key="frame" x="0.0" y="43" width="586" height="26"/>
+                                                                    <rect key="frame" x="0.0" y="43" width="566" height="26"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Unprotected Sites" id="lcM-vz-Ltd">
                                                                         <font key="font" metaFont="systemBold" size="22"/>
@@ -559,14 +559,14 @@
                                                                 <outlet property="textField" destination="aBi-uE-RQS" id="PI9-1v-JrM"/>
                                                             </connections>
                                                         </tableCellView>
-                                                        <tableCellView identifier="Entry" id="i9m-aw-Vzv" customClass="ProtectionEntryTableCellView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="100" width="586" height="50"/>
+                                                        <tableCellView identifier="Entry" id="i9m-aw-Vzv" customClass="ProtectionEntryTableCellView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
+                                                            <rect key="frame" x="10" y="100" width="566" height="50"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="vPq-rW-vBd">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="586" height="50"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="566" height="50"/>
                                                                     <view key="contentView" id="H7z-gc-R6S">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="586" height="50"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="566" height="50"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AmB-jK-ffj">
@@ -664,7 +664,7 @@
                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Exceptions" id="dtH-LG-vGf"/>
                                         </imageView>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4GI-aE-TNs">
-                                            <rect key="frame" x="132" y="211" width="224" height="26"/>
+                                            <rect key="frame" x="133" y="211" width="223" height="26"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="No unprotected sites" id="7v2-fY-5nH">
                                                 <font key="font" metaFont="systemBold" size="22"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -739,7 +739,7 @@
         <!--Home Section View Controller-->
         <scene sceneID="KW6-SJ-uCZ">
             <objects>
-                <viewController storyboardIdentifier="Home" id="4Zn-Kl-PVb" customClass="HomeSectionViewController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Home" id="4Zn-Kl-PVb" customClass="HomeSectionViewController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="omw-7N-PNg">
                         <rect key="frame" x="0.0" y="0.0" width="690" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -749,7 +749,7 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="OnboardingLogo" id="ei6-Rw-d6d"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ok5-Tf-GTo">
-                                <rect key="frame" x="249" y="302" width="192" height="13"/>
+                                <rect key="frame" x="249" y="302" width="193" height="13"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="P R I V A C Y   E S S E N T I A L S  1 . 0" id="H7j-Jt-dzE">
                                     <font key="font" metaFont="systemHeavy" size="10"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -771,7 +771,7 @@
                                             <size key="maxSize" width="508" height="10000000"/>
                                             <attributedString key="textStorage">
                                                 <fragment>
-                                                    <string key="content">DuckDuckGo Privacy Essentials for Safari helps you seamlessly take control of your personal information. Private search, tracker blocking, and more!</string>
+                                                    <string key="content">DuckDuckGo Privacy for Safari helps you seamlessly take control of your personal information. Private search, tracker blocking, and more!</string>
                                                     <attributes>
                                                         <color key="NSColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                         <font key="NSFont" metaFont="menu" size="14"/>
@@ -827,7 +827,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kly-RK-eKj">
-                                            <rect key="frame" x="298" y="42" width="111" height="32"/>
+                                            <rect key="frame" x="297" y="42" width="113" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="99" id="3G3-Qp-I5E"/>
                                             </constraints>
@@ -840,7 +840,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VTF-fs-gyY">
-                                            <rect key="frame" x="298" y="14" width="111" height="32"/>
+                                            <rect key="frame" x="297" y="14" width="113" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="99" id="l0C-xO-bzg"/>
                                             </constraints>
@@ -852,7 +852,7 @@
                                                 <action selector="showDashboardPreferences:" target="4Zn-Kl-PVb" id="cC2-cP-W4t"/>
                                             </connections>
                                         </button>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TL2-OX-Hbd" customClass="ClickableTextField" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TL2-OX-Hbd" customClass="ClickableTextField" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                             <rect key="frame" x="319" y="51" width="68" height="16"/>
                                             <gestureRecognizers>
                                                 <clickGestureRecognizer delaysPrimaryMouseButtonEvents="YES" numberOfClicksRequired="1" id="PGa-5F-wey">
@@ -867,7 +867,7 @@
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OlT-xD-oXa" customClass="ClickableTextField" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OlT-xD-oXa" customClass="ClickableTextField" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                             <rect key="frame" x="319" y="23" width="68" height="16"/>
                                             <gestureRecognizers>
                                                 <clickGestureRecognizer delaysPrimaryMouseButtonEvents="YES" numberOfClicksRequired="1" id="OCA-nj-tNG">
@@ -928,7 +928,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Kyc-ks-BHN">
-                                            <rect key="frame" x="299" y="6" width="110" height="32"/>
+                                            <rect key="frame" x="298" y="7" width="112" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="98" id="qty-DP-27T"/>
                                             </constraints>
@@ -958,7 +958,7 @@
                                 <color key="fillColor" name="HomeScreenFill"/>
                             </box>
                             <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SMy-5a-asi">
-                                <rect key="frame" x="565" y="64" width="25" height="25"/>
+                                <rect key="frame" x="564" y="65" width="25" height="25"/>
                                 <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="SSc-Dd-hfP">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -1010,7 +1010,7 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="FeedbackSent" id="Svk-jx-5a2"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ahO-yt-hV2">
-                                <rect key="frame" x="214" y="223" width="162" height="26"/>
+                                <rect key="frame" x="215" y="223" width="161" height="26"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Feedback Sent" id="sZt-Yz-dxS">
                                     <font key="font" metaFont="systemBold" size="22"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1031,7 +1031,7 @@
                                             <size key="minSize" width="370" height="42"/>
                                             <size key="maxSize" width="388" height="10000000"/>
                                             <attributedString key="textStorage">
-                                                <fragment content="Thank you! Your feedback will help us improve DuckDuckGo Privacy Essentials for Safari.">
+                                                <fragment content="Thank you! Your feedback will help us improve DuckDuckGo Privacy for Safari.">
                                                     <attributes>
                                                         <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                         <font key="NSFont" metaFont="system"/>

--- a/App/Base.lproj/Main.storyboard
+++ b/App/Base.lproj/Main.storyboard
@@ -128,7 +128,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController showSeguePresentationStyle="single" id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="DuckDuckGo - Privacy Essentials" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" animationBehavior="default" tabbingMode="disallowed" id="IQv-IB-iLA">
+                    <window key="window" title="DuckDuckGo Privacy for Safari" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" animationBehavior="default" tabbingMode="disallowed" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="900" height="500"/>

--- a/App/Base.lproj/Main.storyboard
+++ b/App/Base.lproj/Main.storyboard
@@ -17,14 +17,14 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="DuckDuckGo" systemMenu="apple" id="uQy-DD-JDr">
                                     <items>
-                                        <menuItem title="About Privacy Essentials" id="5kV-Vb-QxS">
+                                        <menuItem title="About Privacy for Safari" id="5kV-Vb-QxS">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                                        <menuItem title="Hide Privacy Essentials" keyEquivalent="h" id="QgC-Pb-WsQ">
+                                        <menuItem title="Hide Privacy for Safari" keyEquivalent="h" id="QgC-Pb-WsQ">
                                             <connections>
                                                 <action selector="hide:" target="Ady-hI-5gd" id="8gs-GZ-RdH"/>
                                             </connections>
@@ -42,7 +42,7 @@
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="kHZ-ad-cb2"/>
-                                        <menuItem title="Quit Privacy Essentials" keyEquivalent="q" id="4sb-4s-VLi">
+                                        <menuItem title="Quit Privacy for Safari" keyEquivalent="q" id="4sb-4s-VLi">
                                             <connections>
                                                 <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
                                             </connections>

--- a/App/CircleIndicatorView.swift
+++ b/App/CircleIndicatorView.swift
@@ -1,6 +1,6 @@
 //
 //  CircleIndicatorView.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/App/ExtensionsStateWatcher.swift
+++ b/App/ExtensionsStateWatcher.swift
@@ -1,6 +1,6 @@
 //
 //  ExtensionsManager.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/App/NSColorExtension.swift
+++ b/App/NSColorExtension.swift
@@ -1,6 +1,6 @@
 //
 //  NSColorExtension.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/App/Onboarding/Onboarding.storyboard
+++ b/App/Onboarding/Onboarding.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="AfP-Og-hqd">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="AfP-Og-hqd">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14868"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,7 +10,7 @@
         <!--Onboarding Page Controller-->
         <scene sceneID="P27-Hm-vY6">
             <objects>
-                <pagecontroller id="AfP-Og-hqd" customClass="OnboardingPageController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <pagecontroller id="AfP-Og-hqd" customClass="OnboardingPageController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="Bs8-F4-LKE">
                         <rect key="frame" x="0.0" y="0.0" width="900" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -23,7 +24,7 @@
                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="35" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Gs1-RW-EYN">
                                             <rect key="frame" x="400" y="101" width="100" height="10"/>
                                             <subviews>
-                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="y4f-Nc-qcC" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="y4f-Nc-qcC" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="10" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="10" id="Ndv-BO-UrF"/>
@@ -33,14 +34,14 @@
                                                         <userDefinedRuntimeAttribute type="boolean" keyPath="active" value="YES"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </customView>
-                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="nVi-Tk-Eh8" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="nVi-Tk-Eh8" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                                     <rect key="frame" x="45" y="0.0" width="10" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="10" id="qpb-lq-E7e"/>
                                                         <constraint firstAttribute="width" constant="10" id="wzU-79-Gma"/>
                                                     </constraints>
                                                 </customView>
-                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="3nX-Uf-Mkg" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="3nX-Uf-Mkg" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                                     <rect key="frame" x="90" y="0.0" width="10" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="10" id="aW9-PX-29e"/>
@@ -88,14 +89,14 @@
         <!--Onboarding Get Started Controller-->
         <scene sceneID="tiI-Ys-NMQ">
             <objects>
-                <viewController storyboardIdentifier="GetStarted" id="f9Y-b3-E89" customClass="OnboardingGetStartedController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="GetStarted" id="f9Y-b3-E89" customClass="OnboardingGetStartedController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="YHX-zc-TUw">
                         <rect key="frame" x="0.0" y="0.0" width="900" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yBs-RL-7Yp">
-                                <rect key="frame" x="229" y="235" width="442" height="28"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Enable DuckDuckGo Privacy Essentials" id="uvo-bI-rWV">
+                                <rect key="frame" x="237" y="235" width="427" height="28"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Enable DuckDuckGo Privacy for Safari" id="uvo-bI-rWV">
                                     <font key="font" metaFont="systemBold" size="24"/>
                                     <color key="textColor" name="OnboardingTitleText"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -123,7 +124,7 @@
                                             <size key="minSize" width="423" height="69"/>
                                             <size key="maxSize" width="581" height="10000000"/>
                                             <attributedString key="textStorage">
-                                                <fragment content="Before DuckDuckGo Privacy Essentials will work, you'll need to enable its features within Safari.">
+                                                <fragment content="Before DuckDuckGo Privacy for Safari will work, you'll need to enable its features within Safari.">
                                                     <attributes>
                                                         <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                         <font key="NSFont" metaFont="system" size="15"/>
@@ -149,7 +150,7 @@
                                 </scroller>
                             </scrollView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3aH-wP-8hp">
-                                <rect key="frame" x="354" y="44" width="192" height="32"/>
+                                <rect key="frame" x="353" y="44" width="194" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="180" id="Esj-Y2-nd5"/>
                                 </constraints>
@@ -166,8 +167,8 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="LogoHorizontalText" id="dhZ-2E-Eae"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UET-kF-jZx">
-                                <rect key="frame" x="690" y="455" width="192" height="13"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="P R I V A C Y   E S S E N T I A L S  1 . 0" id="lGw-WR-7sH">
+                                <rect key="frame" x="724" y="455" width="158" height="13"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="P R I V A C Y  F O R  S A F A R I" id="lGw-WR-7sH">
                                     <font key="font" metaFont="systemHeavy" size="10"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -201,13 +202,13 @@
         <!--Onboarding Enable Extensions Controller-->
         <scene sceneID="OAE-3j-Ikk">
             <objects>
-                <viewController storyboardIdentifier="EnableExtensions" id="UPf-Ie-zeu" customClass="OnboardingEnableExtensionsController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="EnableExtensions" id="UPf-Ie-zeu" customClass="OnboardingEnableExtensionsController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="Ue2-PN-5ym">
                         <rect key="frame" x="0.0" y="0.0" width="900" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4kE-rh-WQJ">
-                                <rect key="frame" x="354" y="44" width="192" height="32"/>
+                                <rect key="frame" x="353" y="44" width="194" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="180" id="qKi-EX-hO6"/>
                                 </constraints>
@@ -220,7 +221,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jIR-pB-tTg">
-                                <rect key="frame" x="340" y="433" width="221" height="21"/>
+                                <rect key="frame" x="340" y="433" width="220" height="21"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Enable Safari Extensions" id="v4p-wT-Ivd">
                                     <font key="font" metaFont="systemBold" size="18"/>
                                     <color key="textColor" name="OnboardingTitleText"/>
@@ -270,7 +271,7 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yeu-bq-jYA" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yeu-bq-jYA" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="17" y="122" width="7" height="7"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <userDefinedRuntimeAttributes>
@@ -280,7 +281,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </customView>
-                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e7P-8S-FKd" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e7P-8S-FKd" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="17" y="180" width="7" height="7"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <userDefinedRuntimeAttributes>
@@ -290,7 +291,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </customView>
-                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="isd-mU-QBQ" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="isd-mU-QBQ" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="17" y="56" width="7" height="7"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <userDefinedRuntimeAttributes>
@@ -329,13 +330,13 @@
         <!--Onboarding Set Default Search Controller-->
         <scene sceneID="A8A-TK-d6m">
             <objects>
-                <viewController storyboardIdentifier="SetDefaultSearch" id="n26-cz-W7b" customClass="OnboardingSetDefaultSearchController" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SetDefaultSearch" id="n26-cz-W7b" customClass="OnboardingSetDefaultSearchController" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="OWq-he-coW">
                         <rect key="frame" x="0.0" y="0.0" width="900" height="500"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qKW-ih-IdP">
-                                <rect key="frame" x="326" y="433" width="249" height="21"/>
+                                <rect key="frame" x="327" y="433" width="247" height="21"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Enable DuckDuckGo Search" id="lCZ-4m-L2Z">
                                     <font key="font" metaFont="systemBold" size="18"/>
                                     <color key="textColor" name="OnboardingTitleText"/>
@@ -367,7 +368,7 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="odZ-Tl-5mp" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="odZ-Tl-5mp" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="17" y="180" width="7" height="7"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <userDefinedRuntimeAttributes>
@@ -377,7 +378,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </customView>
-                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uvm-VB-6g0" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uvm-VB-6g0" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="17" y="122" width="7" height="7"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <userDefinedRuntimeAttributes>
@@ -405,7 +406,7 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ku1-cN-brD" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_Essentials" customModuleProvider="target">
+                                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ku1-cN-brD" customClass="CircleIndicatorView" customModule="DuckDuckGo_Privacy_for_Safari" customModuleProvider="target">
                                         <rect key="frame" x="17" y="56" width="7" height="7"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <userDefinedRuntimeAttributes>
@@ -424,10 +425,10 @@
                                 </constraints>
                             </customView>
                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Iz8-tZ-khS">
-                                <rect key="frame" x="264" y="51" width="372" height="21"/>
+                                <rect key="frame" x="264" y="51" width="372" height="20"/>
                                 <subviews>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wz2-vd-WS9">
-                                        <rect key="frame" x="-6" y="-7" width="192" height="32"/>
+                                        <rect key="frame" x="-7" y="-7" width="194" height="32"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="180" id="2ff-ME-Tje"/>
                                         </constraints>
@@ -440,7 +441,7 @@
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9XQ-xS-ZUb">
-                                        <rect key="frame" x="186" y="-7" width="192" height="32"/>
+                                        <rect key="frame" x="185" y="-7" width="194" height="32"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="180" id="Ar2-0z-4Mh"/>
                                         </constraints>

--- a/App/Onboarding/OnboardingEnableExtensionsController.swift
+++ b/App/Onboarding/OnboardingEnableExtensionsController.swift
@@ -1,6 +1,6 @@
 //
 //  OnboardingEnableExtensionsController.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.

--- a/App/Onboarding/OnboardingGetStartedController.swift
+++ b/App/Onboarding/OnboardingGetStartedController.swift
@@ -1,6 +1,6 @@
 //
 //  OnboardingGetStartedController.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.

--- a/App/Onboarding/OnboardingPageController.swift
+++ b/App/Onboarding/OnboardingPageController.swift
@@ -1,6 +1,6 @@
 //
 //  OnboardingPageController.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/App/Onboarding/OnboardingScreen.swift
+++ b/App/Onboarding/OnboardingScreen.swift
@@ -1,6 +1,6 @@
 //
 //  OnboardingScreen.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.

--- a/App/Onboarding/OnboardingSetDefaultSearchController.swift
+++ b/App/Onboarding/OnboardingSetDefaultSearchController.swift
@@ -1,6 +1,6 @@
 //
 //  OnboardingSetDefaultSearchController.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.

--- a/App/SendFeedbackViewController.swift
+++ b/App/SendFeedbackViewController.swift
@@ -1,6 +1,6 @@
 //
 //  SendFeedbackViewController.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/App/Settings.swift
+++ b/App/Settings.swift
@@ -1,6 +1,6 @@
 //
 //  Settings.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/App/TrustedSitesViewController.swift
+++ b/App/TrustedSitesViewController.swift
@@ -1,6 +1,6 @@
 //
 //  TrustedSitesViewController.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.

--- a/App/Utils.swift
+++ b/App/Utils.swift
@@ -1,6 +1,6 @@
 //
 //  Utils.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Privacy Essentials for Safari
+# Contributing to DuckDuckGo Privacy for Safari
 
 Thank you for taking the time to contribute! :sparkles:
 

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -2359,7 +2359,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.macos.UnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DuckDuckGo Privacy Essentials.app/Contents/MacOS/DuckDuckGo Privacy Essentials";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DuckDuckGo Privacy for Safari.app/Contents/MacOS/DuckDuckGo Privacy for Safari";
 			};
 			name = Debug;
 		};
@@ -2380,7 +2380,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.macos.UnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DuckDuckGo Privacy Essentials.app/Contents/MacOS/DuckDuckGo Privacy Essentials";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DuckDuckGo Privacy for Safari.app/Contents/MacOS/DuckDuckGo Privacy for Safari";
 			};
 			name = Release;
 		};

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 		853CE0FC236309EB009E1D66 /* DashboardData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardData.swift; sourceTree = "<group>"; };
 		8540D8CF22BBA356009A2FF4 /* SectionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionButton.swift; sourceTree = "<group>"; };
 		8540D8F122BBE264009A2FF4 /* HomeSectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSectionViewController.swift; sourceTree = "<group>"; };
-		85417D60226605E60062A081 /* DuckDuckGo Privacy Essentials.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DuckDuckGo Privacy Essentials.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		85417D60226605E60062A081 /* DuckDuckGo Privacy for Safari.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DuckDuckGo Privacy for Safari.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		85417D63226605E60062A081 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		85417D65226605E60062A081 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		85417D67226605E60062A081 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -617,6 +617,7 @@
 		AA6820B4254B0E49005ED0D5 /* ToolbarIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = ToolbarIcon.pdf; sourceTree = "<group>"; };
 		AA70F4DC26939C5E001C4846 /* ColorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorView.swift; sourceTree = "<group>"; };
 		AA8B72E52630494E00317524 /* ToolbarIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarIcon.swift; sourceTree = "<group>"; };
+		AAC688222865EE2C00D54247 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -765,6 +766,7 @@
 		85417D57226605E60062A081 = {
 			isa = PBXGroup;
 			children = (
+				AAC688222865EE2C00D54247 /* README.md */,
 				85417D62226605E60062A081 /* App */,
 				85417DAA226762E40062A081 /* ContentBlockerExtension */,
 				85E9522C22B0FDE80071281E /* CoreFramework */,
@@ -785,7 +787,7 @@
 		85417D61226605E60062A081 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				85417D60226605E60062A081 /* DuckDuckGo Privacy Essentials.app */,
+				85417D60226605E60062A081 /* DuckDuckGo Privacy for Safari.app */,
 				85417D8B226762870062A081 /* SafariAppExtension.appex */,
 				85417DA8226762E40062A081 /* ContentBlockerExtension.appex */,
 				8587A6832278901300F622AF /* TrackerBlocking.framework */,
@@ -1116,9 +1118,9 @@
 			productReference = 8524A40C23327568001E8856 /* Feedback.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		85417D5F226605E60062A081 /* DuckDuckGo Privacy Essentials */ = {
+		85417D5F226605E60062A081 /* DuckDuckGo Privacy for Safari */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 85417D70226605E60062A081 /* Build configuration list for PBXNativeTarget "DuckDuckGo Privacy Essentials" */;
+			buildConfigurationList = 85417D70226605E60062A081 /* Build configuration list for PBXNativeTarget "DuckDuckGo Privacy for Safari" */;
 			buildPhases = (
 				854A9F3022706478008F2A93 /* Install Fonts */,
 				85417D73226613900062A081 /* Swiftlint */,
@@ -1140,9 +1142,9 @@
 				85A2CDE22385502F00F780A1 /* PBXTargetDependency */,
 				8528E9E0238843A90029E9D7 /* PBXTargetDependency */,
 			);
-			name = "DuckDuckGo Privacy Essentials";
+			name = "DuckDuckGo Privacy for Safari";
 			productName = DuckDuckGo;
-			productReference = 85417D60226605E60062A081 /* DuckDuckGo Privacy Essentials.app */;
+			productReference = 85417D60226605E60062A081 /* DuckDuckGo Privacy for Safari.app */;
 			productType = "com.apple.product-type.application";
 		};
 		85417D8A226762870062A081 /* SafariAppExtension */ = {
@@ -1390,7 +1392,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				85417D5F226605E60062A081 /* DuckDuckGo Privacy Essentials */,
+				85417D5F226605E60062A081 /* DuckDuckGo Privacy for Safari */,
 				85417D8A226762870062A081 /* SafariAppExtension */,
 				85417DA7226762E40062A081 /* ContentBlockerExtension */,
 				85E9522A22B0FDE80071281E /* Core */,
@@ -1834,7 +1836,7 @@
 		};
 		8587A6902278901400F622AF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 85417D5F226605E60062A081 /* DuckDuckGo Privacy Essentials */;
+			target = 85417D5F226605E60062A081 /* DuckDuckGo Privacy for Safari */;
 			targetProxy = 8587A68F2278901400F622AF /* PBXContainerItemProxy */;
 		};
 		8587A6972278901400F622AF /* PBXTargetDependency */ = {
@@ -2551,7 +2553,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		85417D70226605E60062A081 /* Build configuration list for PBXNativeTarget "DuckDuckGo Privacy Essentials" */ = {
+		85417D70226605E60062A081 /* Build configuration list for PBXNativeTarget "DuckDuckGo Privacy for Safari" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				85417D71226605E60062A081 /* Debug */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -618,6 +618,7 @@
 		AA70F4DC26939C5E001C4846 /* ColorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorView.swift; sourceTree = "<group>"; };
 		AA8B72E52630494E00317524 /* ToolbarIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarIcon.swift; sourceTree = "<group>"; };
 		AAC688222865EE2C00D54247 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		AAC68823286601A600D54247 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -767,6 +768,7 @@
 			isa = PBXGroup;
 			children = (
 				AAC688222865EE2C00D54247 /* README.md */,
+				AAC68823286601A600D54247 /* CONTRIBUTING.md */,
 				85417D62226605E60062A081 /* App */,
 				85417DAA226762E40062A081 /* ContentBlockerExtension */,
 				85E9522C22B0FDE80071281E /* CoreFramework */,

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/ContentBlockerExtension.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/ContentBlockerExtension.xcscheme
@@ -30,8 +30,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85417D5F226605E60062A081"
-               BuildableName = "DuckDuckGo Privacy Essentials.app"
-               BlueprintName = "DuckDuckGo Privacy Essentials"
+               BuildableName = "DuckDuckGo for Safari.app"
+               BlueprintName = "DuckDuckGo Privacy for Safari"
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -62,8 +62,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo Privacy Essentials.app"
-            BlueprintName = "DuckDuckGo Privacy Essentials"
+            BuildableName = "DuckDuckGo for Safari.app"
+            BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -80,8 +80,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo Privacy Essentials.app"
-            BlueprintName = "DuckDuckGo Privacy Essentials"
+            BuildableName = "DuckDuckGo for Safari.app"
+            BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/ContentBlockerExtension.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/ContentBlockerExtension.xcscheme
@@ -30,7 +30,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85417D5F226605E60062A081"
-               BuildableName = "DuckDuckGo for Safari.app"
+               BuildableName = "DuckDuckGo Privacy for Safari.app"
                BlueprintName = "DuckDuckGo Privacy for Safari"
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo for Safari.app"
+            BuildableName = "DuckDuckGo Privacy for Safari.app"
             BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
@@ -80,7 +80,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo for Safari.app"
+            BuildableName = "DuckDuckGo Privacy for Safari.app"
             BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85417D5F226605E60062A081"
-               BuildableName = "DuckDuckGo for Safari.app"
+               BuildableName = "DuckDuckGo Privacy for Safari.app"
                BlueprintName = "DuckDuckGo Privacy for Safari"
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
@@ -60,7 +60,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo for Safari.app"
+            BuildableName = "DuckDuckGo Privacy for Safari.app"
             BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
@@ -109,7 +109,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo for Safari.app"
+            BuildableName = "DuckDuckGo Privacy for Safari.app"
             BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
@@ -126,7 +126,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo for Safari.app"
+            BuildableName = "DuckDuckGo Privacy for Safari.app"
             BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85417D5F226605E60062A081"
-               BuildableName = "DuckDuckGo Privacy Essentials.app"
-               BlueprintName = "DuckDuckGo Privacy Essentials"
+               BuildableName = "DuckDuckGo for Safari.app"
+               BlueprintName = "DuckDuckGo Privacy for Safari"
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -60,8 +60,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo Privacy Essentials.app"
-            BlueprintName = "DuckDuckGo Privacy Essentials"
+            BuildableName = "DuckDuckGo for Safari.app"
+            BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -109,8 +109,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo Privacy Essentials.app"
-            BlueprintName = "DuckDuckGo Privacy Essentials"
+            BuildableName = "DuckDuckGo for Safari.app"
+            BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -126,8 +126,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo Privacy Essentials.app"
-            BlueprintName = "DuckDuckGo Privacy Essentials"
+            BuildableName = "DuckDuckGo for Safari.app"
+            BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/SafariAppExtension.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/SafariAppExtension.xcscheme
@@ -30,8 +30,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85417D5F226605E60062A081"
-               BuildableName = "DuckDuckGo Privacy Essentials.app"
-               BlueprintName = "DuckDuckGo Privacy Essentials"
+               BuildableName = "DuckDuckGo for Safari.app"
+               BlueprintName = "DuckDuckGo Privacy for Safari"
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -62,8 +62,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo Privacy Essentials.app"
-            BlueprintName = "DuckDuckGo Privacy Essentials"
+            BuildableName = "DuckDuckGo for Safari.app"
+            BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -80,8 +80,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo Privacy Essentials.app"
-            BlueprintName = "DuckDuckGo Privacy Essentials"
+            BuildableName = "DuckDuckGo for Safari.app"
+            BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/SafariAppExtension.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/SafariAppExtension.xcscheme
@@ -30,7 +30,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85417D5F226605E60062A081"
-               BuildableName = "DuckDuckGo for Safari.app"
+               BuildableName = "DuckDuckGo Privacy for Safari.app"
                BlueprintName = "DuckDuckGo Privacy for Safari"
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo for Safari.app"
+            BuildableName = "DuckDuckGo Privacy for Safari.app"
             BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
@@ -80,7 +80,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "85417D5F226605E60062A081"
-            BuildableName = "DuckDuckGo for Safari.app"
+            BuildableName = "DuckDuckGo Privacy for Safari.app"
             BlueprintName = "DuckDuckGo Privacy for Safari"
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DuckDuckGo Privacy Essentials for Safari
+# DuckDuckGo Privacy for Safari
 
 ## Building
 Requires Xcode 11 and macOS 10.15 or better.
@@ -27,4 +27,4 @@ Please refer to [contributing](CONTRIBUTING.md).
 Contact us at https://duckduckgo.com/feedback if you have feedback, questions or want to chat.  You can also use the feedback form embedded within the macOS app - to do so open the app and select "Send Feedback".
 
 ## License
-DuckDuckGo Privacy Essentials for Safari is distributed under the Apache 2.0 [license](https://github.com/duckduckgo/privacy-essentials-safari/blob/master/LICENSE).
+DuckDuckGo Privacy for Safari is distributed under the Apache 2.0 [license](https://github.com/duckduckgo/privacy-essentials-safari/blob/master/LICENSE).

--- a/Shared/AppLinks.swift
+++ b/Shared/AppLinks.swift
@@ -1,6 +1,6 @@
 //
 //  AppUrls.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/Shared/AtbLocations.swift
+++ b/Shared/AtbLocations.swift
@@ -1,6 +1,6 @@
 //
 //  AtbLocations.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Created by Chris Brind on 11/11/2019.
 //  Copyright © 2019 Duck Duck Go, Inc. All rights reserved.

--- a/Shared/BundleIds.swift
+++ b/Shared/BundleIds.swift
@@ -22,7 +22,6 @@ import Foundation
 struct BundleIds {
     
     static let app = "com.duckduckgo.macos.PrivacyEssentials"
-    static let appName = "DuckDuckGo Privacy Essentials"
     static let contentBlockerExtension = app + ".ContentBlockerExtension"
     static let safariAppExtension = app + ".SafariAppExtension"
     static let oldSyncApp = app + ".DuckDuckGoSync"

--- a/Shared/BundleIds.swift
+++ b/Shared/BundleIds.swift
@@ -1,6 +1,6 @@
 //
 //  AppIds.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/Shared/Logging.swift
+++ b/Shared/Logging.swift
@@ -1,6 +1,6 @@
 //
 //  Logging.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/Shared/NSAttributedStringExtension.swift
+++ b/Shared/NSAttributedStringExtension.swift
@@ -1,6 +1,6 @@
 //
 //  NSAttributedStringExtension.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/Shared/StringExtension.swift
+++ b/Shared/StringExtension.swift
@@ -1,6 +1,6 @@
 //
 //  StringExtension.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/StatisticsFramework/DeepDetection.swift
+++ b/StatisticsFramework/DeepDetection.swift
@@ -1,6 +1,6 @@
 //
 //  DeepDetection.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/TrackerBlockingFramework/ContentBlockerRulesBuilder.swift
+++ b/TrackerBlockingFramework/ContentBlockerRulesBuilder.swift
@@ -1,6 +1,6 @@
 //
 //  ContentBlockerRulesBuilder.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/TrackerBlockingFramework/DataCompletion.swift
+++ b/TrackerBlockingFramework/DataCompletion.swift
@@ -1,6 +1,6 @@
 //
 //  DataCompletion.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/TrackerBlockingFramework/HttpURLResponseExtension.swift
+++ b/TrackerBlockingFramework/HttpURLResponseExtension.swift
@@ -1,6 +1,6 @@
 //
 //  HTTPURLResponseExtension.swift
-//  DuckDuckGo Privacy Essentials
+//  DuckDuckGo Privacy for Safari
 //
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
 //

--- a/UnitTests/SettingsTests.swift
+++ b/UnitTests/SettingsTests.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 import XCTest
-@testable import DuckDuckGo_Privacy_Essentials
+@testable import DuckDuckGo_Privacy_for_Safari
 
 class SettingsTests: XCTestCase {
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/38424471409662/1202229553802448/f

**Description**:
To better distinguish our macOS products, we are renaming DuckDuckGo Privacy Essentials to DuckDuckGo Privacy for Safari.

**Steps to test this PR**:
1. Make sure app name is DuckDuckGo Privacy for Safari
1. Check following UI elements and make sure they contain "DuckDuckGo Privacy for Safari" or "Privacy for Safari" : Main menu, window title, onboarding view, Home view, Share Feedback view
1. Verify unit tests are passing
1. Take a look at README.md and CONTRIBUTING.md
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
