### PR TITLE
Add 30-minute timeout to the unit tests GHA workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,7 @@ jobs:
     name: Unit Tests
 
     runs-on: macos-12
+    timeout-minutes: 30
 
     steps:
     - name: Check out the code


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203164850287660/f

**Description**:
Add a timeout to terminate workflows early in case they hang up unexpectedly.

**Steps to test this PR**:
1. Ensure that the unit tests workflow runs without a syntax error and finished without unexpected errors

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
